### PR TITLE
Move from personal repo to openshift org repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM quay.io/openshift/origin-cli:v4.0.0
+
+ARG ocpythonlibver=0.8.6
+
+# Dependencies for openshift-restclient-python.
+RUN \
+  cd /tmp && \
+  curl -L https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+  python /tmp/get-pip.py && \
+  pip install setuptools==40.8.0 urllib3==1.24.1 chardet==3.0.4 requests==2.21.0
+
+# Install restclient from source
+RUN \
+  cd /tmp && \ 
+  curl -LO https://github.com/openshift/openshift-restclient-python/archive/v${ocpythonlibver}.tar.gz && \
+  tar xvzf v${ocpythonlibver}.tar.gz && \
+  cd openshift-restclient-python-${ocpythonlibver} && \
+  python setup.py install
+
+COPY src/init.py /usr/local/bin
+
+RUN chmod +x /usr/local/bin/init.py
+
+CMD [ "/bin/sh" ]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,135 @@
+# managed-prometheus-exporter-initcontainer
+
+This is designed to be an [init container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) to populate various files for later use in Prometheus exporter containers.
+
+The operations are related to writing cluster ID, AWS region name, and AWS API credentials to various files.
+
+## Background and Requirements
+
+Various exporters need to make AWS API calls and while the [cloud-credential-operator](https://github.com/openshift/cloud-credential-operator) can provide the access and secret keys, the operator doesn't have any knowledge of the region in which the various AWS resources reside. In order to perform those API calls, that region ID must be provided. Additionally, some of those exporters need to know the cluster ID where it's running. Having the exporter code/containers determine the region and cluster ID is out of scope for them, and so an init container makes sense (determining the information at deploy-time is not feasible).
+
+Luckily, the `Machine` object(s) from the `openshift-machine-api` namespace contain both the region ID and cluster ID.
+
+There's a side effect of using an init container: We can transform the AWS credentials into a format the exporters can use more easily. The reasoning is that since there's already code running to write files out to disk, why not write one more file to disk and save lines of code in the exporter?
+
+### Accessing Cluster Information
+
+To get access to the cluster information we could change our main container to access this information, but those initialization tasks are best suited to init containers. To that end, the [ServiceAccount](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) for the Pod must be granted access to the aforementioned objects by [ClusterRole and RoleBinding](https://kubernetes.io/docs/reference/access-authn-authz/rbac/). A sample one follows:
+
+```yaml
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pod-sa
+  namespace: deployment-ns
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: access-machine-info-cr
+rules:
+- apiGroups: ["machine.openshift.io"]
+  resources: ["machines"]
+  verbs: ["get", "list"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: allow-deploy-access-to-machine-info
+  namespace: openshift-machine-api
+subjects:
+- kind: ServiceAccount
+  name: pod-sa
+  namespace: deployment-ns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: access-machine-info-cr
+```
+
+### AWS Credentials
+
+The [cloud-credential-operator](https://github.com/openshift/cloud-credential-operator) creates a Secret in the specified namespace that has two keys, `aws_secret_access_key` and `aws_access_key_id`, each for the purpose one would expect. Most consumers of those credentials will want them in an ini-file format, and so this init container will handle that as well.
+
+An example request for credentials looks like this:
+
+```yaml
+apiVersion: cloudcredential.openshift.io/v1beta1
+kind: CredentialsRequest
+metadata:
+  name: deployment-aws-credentials
+  namespace: openshift-monitoring
+spec:
+  secretRef:
+    name: my-credentials-secret
+    namespace: openshift-monitoring
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1beta1
+    kind: AWSProviderSpec
+    statementEntries:
+    - effect: Allow
+      action:
+      - cloudwatch:ListMetrics
+      - cloudwatch:GetMetricData
+      resource: "*"
+```
+
+## Usage
+
+An example deployment might look like this
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deploy
+  namespace: deployment-ns
+spec:
+  selector:
+    matchLabels:
+      app: test-deploy
+spec:
+  selector:
+    matchLabels:
+      app: test-deploy
+  template:
+    metadata:
+      labels:
+        app: test-deploy
+    spec:
+      serviceAccountName: pod-sa
+      initContainers:
+      - name: setupcreds
+        image: quay.io/lseelye/yq-kubectl:stable
+        command: [ "/usr/local/bin/init.py" ]
+        volumeMounts:
+        - name: awsrawcreds
+          mountPath: /rawsecrets
+          readOnly: true
+        - name: secrets
+          mountPath: /secrets
+        - name: envfiles
+          mountPath: /config
+      containers:
+      - name: main
+        image: quay.io/openshift/origin-cli:v4.0.0
+        command: [ "/bin/sleep", "86400" ]
+        volumeMounts:
+        - name: secrets
+          mountPath: /secrets
+          readOnly: true
+        - name: envfiles
+          mountPath: /config
+          readOnly: true
+      volumes:
+      - name: awsrawcreds
+        secret:
+          secretName: my-credentials-secret
+      - name: secrets
+        emptyDir: {}
+      - name: envfiles
+        emptyDir: {}
+```
+
+Once the `main` container runs, it will have the AWS configuration (`config.ini` and `credentials.ini`) populated with information from the configmap and secret. Additional usage is to write the cluster ID to a file, which the `main` container will need to `source` as part of its command, to expose `CLUSTERID` as an environment variable, if so desired.

--- a/src/init.py
+++ b/src/init.py
@@ -1,0 +1,80 @@
+#!/usr/bin/python
+
+import argparse
+import os
+
+from kubernetes import client, config
+from kubernetes.client import ApiClient, Configuration
+
+from openshift.dynamic import DynamicClient
+
+parser = argparse.ArgumentParser(description="Options to Program")
+parser.add_argument('-n', default="openshift-machine-api", required=False, dest="namespace", help="Namespace to use")
+parser.add_argument('-c', default="/config/env/CLUSTERID", required=False, dest="clusteridfile", help="Location to write CLUSTERID")
+parser.add_argument('-r', default="/secrets/aws/config.ini", required=False, dest="regionfile", help="Location to write AWS region config.ini")
+parser.add_argument('-o', default="/secrets/aws/credentials.ini", required=False, dest="credsfile", help="Location to write AWS credentials.ini")
+parser.add_argument('-a', default="/secrets/aws_access_key_id", required=False, dest="accesskeyinfile", help="Source of AWS access key")
+parser.add_argument('-A', default="/secrets/aws_secret_access_key", required=False, dest="secretkeyinfile", help="Source of AWS secret key")
+
+args = vars(parser.parse_args())
+
+def ensure_dir(filepath):
+    if not os.path.exists(os.path.dirname(filepath)):
+        os.makedirs(os.path.dirname(filepath))
+
+def get_cluster_id(dclient, namespace):
+    v1b_machines = dclient.resources.get(kind='Machine')
+    return v1b_machines.get(namespace=namespace).items[0][u'metadata'][u'labels'][u'sigs.k8s.io/cluster-api-cluster']
+
+def get_region_id(dclient, namespace):
+    v1b_machines = dclient.resources.get(kind='Machine')
+    return v1b_machines.get(namespace=namespace).items[0][u'spec'][u'providerSpec'][u'value'][u'placement'][u'region']
+
+def write_region_config(dest, regionid):
+    ensure_dir(dest)
+
+    with open(dest, 'wb') as cfgfile:
+        cfgfile.write('[default]\n')
+        cfgfile.write('region = {}\n'.format(regionid))
+
+def write_credentials_file(dest, access_key_id, secret_key_id):
+    ensure_dir(dest)
+
+    with open(dest, 'wb') as cfgfile:
+        cfgfile.write('[default]\n')
+        cfgfile.write('aws_access_key_id = {}\n'.format(access_key_id))
+        cfgfile.write('aws_secret_access_key = {}\n'.format(secret_key_id))
+
+def write_cluster_id(dest, clusterid):
+    ensure_dir(dest)
+
+    with open(dest, 'wb') as clusterfile:
+        clusterfile.write('CLUSTERID="{}"\n'.format(clusterid))
+
+def read_aws_access_key(src):
+    ''' Attempt to read the value of the AWS access key
+    '''
+    f = open(src, 'r')
+    return f.readline()
+
+def read_aws_secret_key(src):
+    ''' Attempt to read the value of the AWS secret key
+    '''
+    f = open(src, 'r')
+    return f.readline()
+
+
+incluster = config.load_incluster_config()
+k8s_client = ApiClient(incluster)
+dclient = DynamicClient(k8s_client)
+
+# Write everything, cos why not?
+try:
+    access_key = read_aws_access_key(args['accesskeyinfile'])
+    secret_key = read_aws_secret_key(args['secretkeyinfile'])
+    write_credentials_file(args['credsfile'], access_key, secret_key)
+    write_region_config(args['regionfile'], get_region_id(dclient, args['namespace']))
+except IOError as err:
+    print("Not writing AWS credentials because there aren't any source files.")
+
+write_cluster_id(args['clusteridfile'], get_cluster_id(dclient, args['namespace']))


### PR DESCRIPTION
This code formerly lived in @lisa's personal repo, https://github.com/lisa/docker-yq-kubectl but for a number of reasons is being moved (first of which being that this is no longer based on `yq` _or_ `kubectl`). A brief history will be available in the other repository.

Signed-off-by: Lisa Seelye <lseelye@redhat.com>