### PR TITLE
Added Makefile and setup version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,30 @@
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 include version.mk
 
-IMAGE_URI=quay.io/redhat/managed-prometheus-exporter-initcontainer
+IMAGE_REPO=quay.io/redhat
+IMAGE_NAME=managed-prometheus-exporter-initcontainer
 
 VERSION_MAJOR=0
 VERSION_MINOR=1
 
+# VERSION_FULL is generated in version.mk and requires input VERSION_MAJOR and VERSION_MINOR
+
+.PHONY: all
 all: build tag push
 
+.PHONY: clean
+clean:
+	docker rmi $(IMAGE_REPO)/$(IMAGE_NAME):$(VERSION_FULL) -f
+
+.PHONY: build
 build:
-	docker build . -t $(IMAGE_URI):latest
+	docker build . -t $(IMAGE_REPO)/$(IMAGE_NAME):$(VERSION_FULL)
 
+.PHONY: tag
 tag:
-	docker tag $(IMAGE_URI):latest $(IMAGE_URI):$(VERSION_FULL)
+	docker tag $(IMAGE_REPO)/$(IMAGE_NAME):$(VERSION_FULL) $(IMAGE_REPO)/$(IMAGE_NAME):latest
 
+.PHONY: push
 push:
-	docker push $(IMAGE_URI):latest
-	docker push $(IMAGE_URI):$(VERSION_FULL)
+	docker push $(IMAGE_REPO)/$(IMAGE_NAME):$(VERSION_FULL)
+	docker push $(IMAGE_REPO)/$(IMAGE_NAME):latest

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+SHELL := /bin/bash
+include version.mk
+
+IMAGE_URI=quay.io/redhat/managed-prometheus-exporter-initcontainer
+
+VERSION_MAJOR=0
+VERSION_MINOR=1
+
+all: build tag push
+
+build:
+	docker build . -t $(IMAGE_URI):latest
+
+tag:
+	docker tag $(IMAGE_URI):latest $(IMAGE_URI):$(VERSION_FULL)
+
+push:
+	docker push $(IMAGE_URI):latest
+	docker push $(IMAGE_URI):$(VERSION_FULL)

--- a/version.mk
+++ b/version.mk
@@ -1,0 +1,5 @@
+COMMIT_NUMBER=$(shell git rev-list `git rev-list --parents HEAD | egrep "^[a-f0-9]{40}$$"`..HEAD --count)
+BUILD_DATE=$(shell date --utc +%Y-%m-%d)
+CURRENT_COMMIT=$(shell git rev-parse --short=8 HEAD)
+VERSION_FULL=$(VERSION_MAJOR).$(VERSION_MINOR).$(COMMIT_NUMBER)-$(BUILD_DATE)-$(CURRENT_COMMIT)
+

--- a/version.mk
+++ b/version.mk
@@ -1,5 +1,5 @@
 COMMIT_NUMBER=$(shell git rev-list `git rev-list --parents HEAD | egrep "^[a-f0-9]{40}$$"`..HEAD --count)
-BUILD_DATE=$(shell date --utc +%Y-%m-%d)
+BUILD_DATE=$(shell date -u +%Y-%m-%d)
 CURRENT_COMMIT=$(shell git rev-parse --short=8 HEAD)
 VERSION_FULL=$(VERSION_MAJOR).$(VERSION_MINOR).$(COMMIT_NUMBER)-$(BUILD_DATE)-$(CURRENT_COMMIT)
 


### PR DESCRIPTION
Version based on recent SRE standard.  Not published yet, but it's:
- major.minor.commit#-CCYY-MM-DD-gitHash

with:

- major - follow semver, set manually
- minor - follow semver, set manually
- commit# - similar to semver patch, but is just the number of the commit from the root of the repository
- CCYY - year built (UTC) i.e. 2019
- MM - month built (UTC) i.e. 03
- DD - day of month built (UTC), i.e. 27
- gitHash - the first 8 chars of git hash i.e. git rev-parse --short=8 HEAD
