### PR TITLE
Force pulling latest base image before a build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ clean:
 
 .PHONY: build
 build:
-	docker build . -t $(IMAGE_REPO)/$(IMAGE_NAME):$(VERSION_FULL)
+	docker build --pull . -t $(IMAGE_REPO)/$(IMAGE_NAME):$(VERSION_FULL)
 
 .PHONY: tag
 tag:


### PR DESCRIPTION
Noticed I had an old origin-cli pulled locally.  Builds do not update it if an image matches already.  Added a pull before build which will pull the latest image.  Originally inspired to see if I could remove some vulnerabilities (base image requires Red Hat subscription to yum update, I don't have that setup on my workstation).