### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,35 @@
 SHELL := /usr/bin/env bash
-include version.mk
 
-IMAGE_REPO=quay.io/openshift-sre
-IMAGE_NAME=managed-prometheus-exporter-initcontainer
+# Include project specific values file
+# Requires the following variables:
+# - IMAGE_REPO
+# - IMAGE_NAME
+# - VERSION_MAJOR
+# - VERSION_MINOR
+include project.mk
 
-VERSION_MAJOR=0
-VERSION_MINOR=1
+# Validate variables in project.mk exist
+ifndef IMAGE_REPO
+$(error IMAGE_REPO is not set; check project.mk file)
+endif
+ifndef IMAGE_NAME
+$(error IMAGE_NAME is not set; check project.mk file)
+endif
+ifndef VERSION_MAJOR
+$(error VERSION_MAJOR is not set; check project.mk file)
+endif
+ifndef VERSION_MINOR
+$(error VERSION_MINOR is not set; check project.mk file)
+endif
 
-# VERSION_FULL is generated in version.mk and requires input VERSION_MAJOR and VERSION_MINOR
+# Generate version and tag information from inputs
+COMMIT_NUMBER=$(shell git rev-list `git rev-list --parents HEAD | egrep "^[a-f0-9]{40}$$"`..HEAD --count)
+BUILD_DATE=$(shell date -u +%Y-%m-%d)
+CURRENT_COMMIT=$(shell git rev-parse --short=8 HEAD)
+VERSION_FULL=v$(VERSION_MAJOR).$(VERSION_MINOR).$(COMMIT_NUMBER)-$(BUILD_DATE)-$(CURRENT_COMMIT)
+
+.PHONY: default
+default: build
 
 .PHONY: all
 all: build tag push

--- a/project.mk
+++ b/project.mk
@@ -1,0 +1,6 @@
+# Project specific values
+IMAGE_REPO=quay.io/openshift-sre
+IMAGE_NAME=managed-prometheus-exporter-initcontainer
+
+VERSION_MAJOR=0
+VERSION_MINOR=1

--- a/version.mk
+++ b/version.mk
@@ -1,5 +1,0 @@
-COMMIT_NUMBER=$(shell git rev-list `git rev-list --parents HEAD | egrep "^[a-f0-9]{40}$$"`..HEAD --count)
-BUILD_DATE=$(shell date -u +%Y-%m-%d)
-CURRENT_COMMIT=$(shell git rev-parse --short=8 HEAD)
-VERSION_FULL=v$(VERSION_MAJOR).$(VERSION_MINOR).$(COMMIT_NUMBER)-$(BUILD_DATE)-$(CURRENT_COMMIT)
-


### PR DESCRIPTION
- Extract project specific configuration into separate file
- Add error checking for project specific variables
- Set default make rule, so default isn't all

The idea of this is `Makefile` is generic, while anything that is project specific would be in `project.mk`

Let me know what you think :)