### PR TITLE
Don't open in binary mode

### DIFF
--- a/src/init.py
+++ b/src/init.py
@@ -33,14 +33,14 @@ def get_region_id(dclient, namespace):
 def write_region_config(dest, regionid):
     ensure_dir(dest)
 
-    with open(dest, 'wb') as cfgfile:
+    with open(dest, 'w') as cfgfile:
         cfgfile.write('[default]\n')
         cfgfile.write('region = {}\n'.format(regionid))
 
 def write_credentials_file(dest, access_key_id, secret_key_id):
     ensure_dir(dest)
 
-    with open(dest, 'wb') as cfgfile:
+    with open(dest, 'w') as cfgfile:
         cfgfile.write('[default]\n')
         cfgfile.write('aws_access_key_id = {}\n'.format(access_key_id))
         cfgfile.write('aws_secret_access_key = {}\n'.format(secret_key_id))
@@ -48,7 +48,7 @@ def write_credentials_file(dest, access_key_id, secret_key_id):
 def write_cluster_id(dest, clusterid):
     ensure_dir(dest)
 
-    with open(dest, 'wb') as clusterfile:
+    with open(dest, 'w') as clusterfile:
         clusterfile.write('CLUSTERID="{}"\n'.format(clusterid))
 
 def read_aws_access_key(src):


### PR DESCRIPTION
This evidently worked with python2, but does not work with python3 (thanks 2to3).